### PR TITLE
Moving basic clang-psp script to pspdev-master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+mipsel-sony-psp

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# clang-psp
-New toolchain approach for PSP
+# Clang build for Playstation Portable 
+
+All you need to do is run sudo ./toolchain.sh :)
+

--- a/resources/cmake/BuildPRX.cmake
+++ b/resources/cmake/BuildPRX.cmake
@@ -1,0 +1,8 @@
+macro(build_prx elf)
+	message(Building PRX)
+	add_custom_command(
+		TARGET ${elf}
+		POST_BUILD COMMAND
+		${PRXGEN} ${elf} ${elf}.prx
+	)
+endmacro()

--- a/resources/cmake/CreatePBP.cmake
+++ b/resources/cmake/CreatePBP.cmake
@@ -1,0 +1,84 @@
+# File defining macro outputting PSP-specific EBOOT.PBP out of passed executable target.
+# Copyright 2020 - Daniel 'dbeef' Zalega
+#
+# Args:
+# TARGET - defined by an add_executable call before calling create_pbp_file
+# TITLE - optional, string, target's name in PSP menu
+# ICON_PATH - optional, absolute path to .png file, 144x82
+# BACKGROUND_PATH - optional, absolute path to .png file, 480x272
+# PREVIEW_PATH - optional, absolute path to .png file, 480x272
+#
+cmake_minimum_required(VERSION 3.10)
+
+macro(create_pbp_file)
+
+    set(oneValueArgs TARGET TITLE ICON_PATH BACKGROUND_PATH PREVIEW_PATH)
+    cmake_parse_arguments("ARG" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # As pack-pbp takes undefined arguments in form of "NULL" string,
+    # set each undefined macro variable to such value:
+    foreach(arg ${oneValueArgs})
+        if (NOT DEFINED ARG_${arg})
+            set(ARG_${arg} "NULL")
+        endif()
+    endforeach()
+
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+        add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${STRIP}" "$<TARGET_FILE:${ARG_TARGET}>"
+            COMMENT "Stripping binary"
+        )
+    else()
+        add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            ${CMAKE_COMMAND} -E cmake_echo_color --cyan "Not stripping binary, build type is ${CMAKE_BUILD_TYPE}."
+        )
+    endif()
+
+    add_custom_command(
+            TARGET ${ARG_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory
+            $<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact
+            COMMENT "Creating psp_artifact directory."
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:${ARG_TARGET}>
+            $<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact
+            COMMENT "Copying ELF to psp_arfitact directory."
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${FIXUP}" "$<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact/${ARG_TARGET}"
+            COMMENT "Calling psp-fixup-imports"
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${MKSFOEX}" "-d" "MEMSIZE=1" "${ARG_TITLE}" "PARAM.SFO"
+            COMMENT "Calling mksfoex"
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${PACK_PBP}" "EBOOT.PBP" "PARAM.SFO" "${ARG_ICON_PATH}" "NULL" "${ARG_PREVIEW_PATH}"
+            "${ARG_BACKGROUND_PATH}" "NULL" "$<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact/${ARG_TARGET}" "NULL"
+            COMMENT "Calling pack-pbp"
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            ${CMAKE_COMMAND} -E cmake_echo_color --cyan "EBOOT.PBP file created."
+    )
+
+endmacro()

--- a/resources/cmake/PSP.cmake
+++ b/resources/cmake/PSP.cmake
@@ -1,0 +1,15 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR mips)
+
+set(triple mips-unknown-linux)
+set (CMAKE_SYSROOT $ENV{PSPDEV}/psp)
+
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
+set(CMAKE_C_FLAGS "--config $ENV{PSPSDK}/lib/clang.conf")
+set(CMAKE_CXX_FLAGS "--config $ENV{PSPSDK}/lib/clang.conf" )
+

--- a/resources/cmake/pspold.cmake
+++ b/resources/cmake/pspold.cmake
@@ -1,0 +1,77 @@
+#
+# CMake toolchain file for PSP.
+#
+# Copyright 2019 - Wally
+# Copyright 2020 - Daniel 'dbeef' Zalega
+
+if (DEFINED PSPDEV)
+    # Custom PSPDEV passed as cmake call argument.
+else()
+    # Determine PSP toolchain installation directory;
+    # psp-config binary is guaranteed to be in path after successful installation:
+    execute_process(COMMAND bash -c "psp-config --pspdev-path" OUTPUT_VARIABLE PSPDEV OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# Assert that PSP SDK path is now defined:
+if (NOT DEFINED PSPDEV)
+    message(FATAL_ERROR "PSPDEV not defined. Make sure psp-config in your path or pass custom \
+                        toolchain location via PSPDEV variable in cmake call.")
+endif ()
+
+# Set helper variables:
+set(PSPSDK ${PSPDEV}/psp/sdk)
+set(PSPBIN ${PSPDEV}/bin)
+set(PSPCMAKE ${PSPDEV}/psp/share/cmake)
+
+# Basic CMake Declarations
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR mips)
+set(triple mipsel-unknown-linux)
+
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_C_FLAGS "-mcpu=mips2 -msingle-float -mno-check-zero-division -D__psp__ -include clang_psp.h -fuse-ld=lld -nostdlib -L$PSPDEV/psp/lib -Wl,--no-dynamic-linker")
+
+set(CMAKE_FIND_ROOT_PATH "${PSPSDK};${PSPDEV}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Set paths to PSP-specific utilities:
+set(MKSFO ${PSPBIN}/mksfo)
+set(MKSFOEX ${PSPBIN}/mksfoex)
+set(PACK_PBP ${PSPBIN}/pack-pbp)
+set(FIXUP ${PSPBIN}/psp-fixup-imports)
+set(ENC ${PSPBIN}/PrxEncrypter)
+set(STRIP ${PSPBIN}/psp-strip)
+
+# Include directories:
+add_definitions("-D__psp__ -mcpu=mips2 -msingle-float -mno-check-zero-division -include clang_psp.h -fuse-ld=lld -nostdlib -L$PSPDEV/psp/lib -Wl,--no-dynamic-linker")
+include_directories( SYSTEM /usr/mipsel-sony-psp/psp/include /usr/mipsel-sony-psp/psp/sdk/include)
+# Discard debug information:
+#add_definitions("-G0")
+
+# Definitions that may be needed to use some libraries:
+add_definitions("-D__PSP__")
+#add_definitions("-DHAVE_OPENGL")
+
+# Aggregated list of all PSP-specific libraries for convenience.
+set(PSP_LIBRARIES
+        "-lg -lc -lpspdebug -lpspctrl -lpspsdk \
+        -lpspnet -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpspaudiolib \
+        -lpsputility -lGL \
+        -lpspvfpu -lpspdisplay -lpsphprm -lpspirkeyb \
+        -lpsprtc -lpspaudio -lpspvram  -lpspgu -lpspge -lpspuser \
+        -L${PSPSDK}/lib -L${PSPDEV}/lib"
+)
+
+# File defining macro outputting PSP-specific EBOOT.PBP out of passed executable target:
+#include("${PSPCMAKE}/CreatePBP.cmake")
+
+# Helper variable for multi-platform projects to identify current platform:
+set(PLATFORM_PSP TRUE BOOL)

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -1,0 +1,141 @@
+#!/bin/bash 
+
+#PSP Development Toolchain deployment script
+#Copyright PSPDev Team 2020 and designed by Wally
+#This script is designed to be deployed automatically via CI, new binaries are offered via CI
+
+#TODO Fetch ncurses-dev / libusb-1.0 and readline-dev packages zlib
+
+CLANG_VER="10" ## Change this when a new version of llvm / clang becomes avaliable 
+BASE_DIR="$PWD"
+BUILD_DIR="$BASE_DIR/build"
+RUST_URL="https://github.com/overdrivenpotato/rust-psp"
+PSPSDK_URL="https://github.com/wally4000/pspsdk" #This is temporary until the SDK is stable and we can merge back to base
+NEWLIB_URL="https://github.com/overdrivenpotato/newlib"
+PSPLINK_URL="https://github.com/pspdev/psplinkusb"
+
+PREFIX="$BASE_DIR/mipsel-sony-psp"
+PSPDEV=$PREFIX
+PSPSDK=$PREFIX/psp/sdk
+PATH=$PATH:$PSPDEV/bin
+
+function fetch_clang
+{
+    bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+
+    # LLVM & Clang
+    apt-get -y install libllvm-$CLANG_VER-ocaml-dev libllvm$CLANG_VER llvm-$CLANG_VER llvm-$CLANG_VER-dev llvm-$CLANG_VER-doc llvm-$CLANG_VER-examples llvm-$CLANG_VER-runtime
+    apt-get -y install clang-$CLANG_VER clang-tools-$CLANG_VER clang-$CLANG_VER-doc libclang-common-$CLANG_VER-dev libclang-$CLANG_VER-dev libclang1-$CLANG_VER clang-format-$CLANG_VER python-clang-$CLANG_VER clangd-$CLANG_VER
+    # libfuzzer, lldb, lld (linker), libc++, OpenMP
+    apt-get -y install libfuzzer-$CLANG_VER-dev lldb-$CLANG_VER lld-$CLANG_VER libc++-$CLANG_VER-dev libc++abi-$CLANG_VER-dev libomp-$CLANG_VER-dev
+
+    apt-get -y install git texi2html 
+}
+
+function prep_sources
+{
+    mkdir build; cd build
+    git clone $RUST_URL --depth=1
+    git clone $PSPSDK_URL --depth=1
+    git clone $NEWLIB_URL -b newlib-3_20_0-PSP --depth=1
+    git clone $PSPLINK_URL --depth=1
+
+    mkdir -p "$PREFIX/psp/share"
+    mkdir "$PREFIX/bin"
+}
+
+## Configure Rust - This will fall into root
+function fetch_rust
+{
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+    export PATH=$PATH:$HOME/.cargo/bin
+    source $HOME/.cargo/env
+    rustup set profile minimal
+    rustup toolchain install nightly-2020-07-02
+    rustup default nightly-2020-07-02 && rustup component add rust-src
+    rustup update
+    cargo install cargo-psp xargo
+}
+
+function compile_libpsp
+{
+    cat << EOF > $BUILD_DIR/rust-psp/psp/Xargo.toml
+    [target.mipsel-sony-psp.dependencies.core]
+    [target.mipsel-sony-psp.dependencies.alloc]
+    [target.mipsel-sony-psp.dependencies.panic_unwind]
+    stage = 1
+EOF
+
+    cd $BUILD_DIR/rust-psp/psp
+    xargo rustc --features stub-only --target mipsel-sony-psp -- -C opt-level=3 -C panic=abort
+    cd $BUILD_DIR
+}
+
+function populateSDK
+{
+    cd $BUILD_DIR/pspsdk
+    ./bootstrap
+    mkdir build; cd build
+    ../configure PSP_CC=clang PSP_CFLAGS="--config $PREFIX/psp/sdk/lib/clang.conf" PSP_CXX=clang++ PSP_AS=llvm-as PSP_LD=ld.lld PSP_AR=llvm-ar PSP_NM=llvm-nm PSP_RANLIB=llvm-ranlib --with-pspdev=$PREFIX --disable-sonystubs --disable-psp-graphics --disable-psp-libc
+    make -j$(nproc) install-data
+    cd $BUILD_DIR
+}
+
+function fetch_newlib
+{
+cd $BUILD_DIR/newlib
+mkdir build && cd build
+CC=clang-$CLANG_VER ../configure AR_FOR_TARGET=llvm-ar-$CLANG_VER AS_FOR_TARGET=llvm-as-$CLANG_VER RANLIB_FOR_TARGET=llvm-ranlib-$CLANG_VER CC_FOR_TARGET=clang-$CLANG_VER CXX_FOR_TARGET=clang++-$CLANG_VER --target=psp --enable-newlib-iconv --enable-newlib-multithread --enable-newlib-mb --prefix=$PREFIX
+make -j$(nproc)
+make -j$(nproc) install
+cd $BUILD_DIR
+}
+
+function compileSDK
+{
+    cd $BUILD_DIR/pspsdk/build
+    make -j$(nproc) 
+    make -j$(nproc) install
+    cd $BUILD_DIR
+    cp -r "$BASE_DIR/resources/cmake" "$PREFIX/psp/share"
+    cp "$HOME/.cargo/bin/pack-pbp" "$PREFIX/bin"
+    cp "$HOME/.cargo/bin/mksfo" "$PREFIX/bin"
+    cp "$BUILD_DIR/rust-psp/target/mipsel-sony-psp/debug/libpsp.a" "$PREFIX/psp/sdk/lib"
+    cd $BUILD_DIR
+}
+
+function fetch_psplink
+{
+    ## Will fail if libusb 1.0 is not present
+    clang-$CLANG_VER psplinkusb/usbhostfs_pc/main.c -Ipsplinkusb/usbhostfs  -DPC_SIDE -D_FILE_OFFSET_BITS=64 -lusb -lpthread -o $PREFIX/bin/usbhostfs_pc
+    clang++-$CLANG_VER psplinkusb/pspsh/*.c -Ipsplinkusb/psplink -D_PCTERM -lreadline -lcurses -o $PREFIX/bin/pspsh
+}
+
+function fetch_libraries
+{
+    ## Fetches PSP Libraries
+
+    git clone https://github.com/take-cheeze/pthreads-emb/ --depth=1
+
+    ## Installs Libraries
+    cd pthreads-emb
+make -C platform/psp -j$(nproc) && make -C platform/psp install
+cp -v *.h `psp-config --psp-prefix`/include
+
+##libcxx
+## Fetch llvm
+## cd build-libcxx
+## cmake -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/cmake/PSP.cmake -DLIBCXX_ENABLE_SHARED=0 -DLIBCXX_HAS_PTHREAD_API=1 -DCMAKE_INSTALL_PREFIX=$PSPDEV/psp ../libcxx
+}
+
+
+#fetch_clang
+prep_sources
+fetch_rust
+compile_libpsp
+populateSDK
+fetch_newlib
+compileSDK
+#fetch_psplink
+fetch_libraries


### PR DESCRIPTION
Here's the basic clang script merged from my repo:

What it does:

Builds everything essential to get C projects working with clang on the psp repo

What it doesn't:
libcxx has not been implemented yet and is very WIP. 